### PR TITLE
fix: add missing infer script and post-publication fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### What's changed
+
+Some fixes to enable training the model:
+- committed the missing script `infer.py`
+- changed config default bert model to `camembert-base`
+- put `config.cfg` as a dependency, not params
+- default to cpu training
+- allow for missing metadata (i.e. omop's `note_class_source_value`)
+
 ## v0.2.0 - 2023-05-04
 
 Many fixes along the publication of our [article](https://arxiv.org/pdf/2303.13451.pdf):

--- a/configs/config.cfg
+++ b/configs/config.cfg
@@ -4,7 +4,7 @@ dev = null
 vectors = null
 init_tok2vec = null
 #bert = "/export/home/share/datascientists/models/camembert-base"
-bert = "/export/home/pwajsburt/data/models/embedding-whole-word/checkpoint-250000/"
+bert = "camembert-base"
 
 [system]
 gpu_allocator = "pytorch"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,7 +68,21 @@ To use it, execute
 ```python
 import eds_pseudonymisation
 
+# Load the machine learning model
 nlp = eds_pseudonymisation.load()
+
+# Add optional rule-based components
+nlp.add_pipe("eds.remove-lowercase", name="remove-lowercase")
+nlp.add_pipe("eds.accents", name="accents")
+nlp.add_pipe(
+    "pseudonymisation-rules",
+    name="pseudonymisation-rules",
+    config={"pattern_keys": ["TEL", "MAIL", "SECU"]},
+)
+nlp.add_pipe("pseudonymisation-addresses", name="pseudonymisation-addresses")
+nlp.add_pipe("structured-data-matcher", name="structured-data-matcher")
+
+# Apply it to a text
 doc = nlp(
     """En 1815, M. Charles-François-Bienvenu
 Myriel était évêque de Digne. C’était un vieillard

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,8 +1,0 @@
-@misc{GROBID,
-  archiveprefix = {swh},
-  eprint        = {1:dir:dab86b296e3c3216e2241968f0d63b68e8209d3c},
-  publisher     = {GitHub},
-  title         = {GROBID},
-  url           = {https://github.com/kermitt2/grobid},
-  year          = {2008--2021}
-}

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -9,8 +9,7 @@ stages:
       - eds_pseudonymisation
       - scripts/convert.py
       - scripts/infer.py
-    params:
-      - configs/config.cfg:
+      - configs/config.cfg
     cmd:
       - cat configs/config.cfg
       - python -m spacy project run xp

--- a/poetry.lock
+++ b/poetry.lock
@@ -5021,6 +5021,18 @@ docs = ["setuptools-rust", "sphinx", "sphinx-rtd-theme"]
 testing = ["black (==22.3)", "datasets", "numpy", "pytest", "requests"]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -5601,4 +5613,4 @@ cuda92 = ["cupy-cuda92"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">3.7.6,<3.12,!=3.8.1"
-content-hash = "6459b02455a229c409a552ce5df7a45aeb3e35af6e052f15c10bd45d93788ffe"
+content-hash = "9f2b59bdec727b1247f4e80d0cf612ccb5213022fc67b90eae1584a91db44d09"

--- a/project.yml
+++ b/project.yml
@@ -38,7 +38,7 @@ vars:
   training: "training"
   seed: 0
   fraction: 200
-  gpu_id: 0
+  gpu_id: -1
 
 env:
   registry_token: GITLAB_REGISTRY_TOKEN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ pytest = "^7.1.1"
 pytest-cov = "^3.0.0"
 mypy = "^0.950"
 coverage = "^6.5.0"
+toml = "^0.10.2"
+wheel = "^0.40.0"
 
 [tool.poetry.group.docs]
 optional = true

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -62,7 +62,7 @@ def convert_jsonl(
         (text, note_id, note_class_source_value, entities, context, split,) = (
             annot["note_text"],
             annot["note_id"],
-            annot["note_class_source_value"],
+            annot.get("note_class_source_value", None),
             annot.get("entities", []),
             annot.get("context", {}),
             annot.get("split", None),

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from typing import Optional
+
+import spacy
+import typer
+from spacy.tokens import DocBin
+from tqdm import tqdm
+
+
+def main(
+    model: Optional[Path] = typer.Option(None, help="Path to the model"),
+    data: Path = typer.Option(
+        ..., help="Path to the evaluation dataset, in spaCy format"
+    ),
+    output: Path = typer.Option(
+        ..., help="Path to the output dataset, in spaCy format"
+    ),
+):
+    """Partition the data into train/test/dev split."""
+
+    spacy.prefer_gpu()
+
+    nlp = spacy.load(model)
+
+    db = DocBin().from_disk(data)
+    input_docs = []
+    for doc in db.get_docs(nlp.vocab):
+        doc.ents = []
+        input_docs.append(doc)
+
+    print("Number of docs:", len(input_docs))
+
+    out_db = DocBin(store_user_data=True)
+    for doc in tqdm(nlp.pipe(input_docs), total=len(input_docs)):
+        doc.user_data = {k: v for k, v in doc.user_data.items() if "trf_data" not in k}
+        out_db.add(doc)
+
+    out_db.to_disk(output)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## Description

Some fixes to enable training the model:
- committed the missing script `infer.py`
- changed config default bert model to `camembert-base`
- put `config.cfg` as a dependency, not params
- default to cpu training
- allow for missing metadata (i.e. omop's `note_class_source_value`)

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [] If this PR is a bug fix, the bug is documented in the test suite.
- [] Changes were documented in the changelog (pending section).
- [] If necessary, changes were made to the documentation.
