### PR TITLE
Fix module discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ exclude_lines = [
 ]
 
 [tool.setuptools.packages]
-find = {where = ["eds_pseudo"], include = ["eds_pseudo*"], namespaces = false}
+find = {where = ["."], include = ["eds_pseudo*"], namespaces = false}
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ exclude_lines = [
 ]
 
 [tool.setuptools.packages]
-find = {where = ["."], include = ["eds_pseudo*"], namespaces = false}
+find = {where = ["."], include = ["eds_pseudo*"]}
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ exclude_lines = [
 ]
 
 [tool.setuptools.packages]
-find = {where = ["eds_pseudo"], namespaces = false}
+find = {where = ["eds_pseudo"], include = ["eds_pseudo*"], namespaces = false}
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,8 @@ exclude_lines = [
     "Token.set_extension.*",
 ]
 
-[tool.setuptools]
-packages = ["eds_pseudo"]
+[tool.setuptools.packages]
+find = {where = ["eds_pseudo"], namespaces = false}
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
While installing the module with the current `pyproject.toml`, the only installed files are `adapter.py` and `scorer.py`.
In order to detect the `pipes` I suggest to use the `setuptools.packages` `find` directive, the following PR fix that.